### PR TITLE
更新 API URL，使用 https 协议

### DIFF
--- a/custom_components/hisense/pyhisenseapi.py
+++ b/custom_components/hisense/pyhisenseapi.py
@@ -51,7 +51,7 @@ class HiSenseLogin:
 
     async def get_home_id_list(self, access_token):
         timestamp = self.get_timestamp()
-        url='http://api.wg.hismarttv.com/wg/dm/getHomeList'
+        url='https://api-wg.hismarttv.com/wg/dm/getHomeList'
         
         headers = {
                 'Host': 'api.wg.hismarttv.com',
@@ -82,7 +82,7 @@ class HiSenseLogin:
             
     async def get_device_wifi_id_dict(self, access_token, home_id, device_keywords="空调"):
         timestamp = self.get_timestamp()
-        url='http://api-wg.hismarttv.com/wg/dm/getHomeDeviceList'
+        url='https://api-wg.hismarttv.com/wg/dm/getHomeDeviceList'
         headers = {
                 'Host': 'api-wg.hismarttv.com',
                 'Connection': 'Keep-Alive',


### PR DESCRIPTION
`api.wg.hismarttv.com` 域名不支持 https，`api-wg.hismarttv.com` 域名可以支持。经过测试，两个域名都可以用。