### PR TITLE
feat: add read-only support for Hisense 00f washers

### DIFF
--- a/custom_components/hisense/__init__.py
+++ b/custom_components/hisense/__init__.py
@@ -3,7 +3,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN
 from .coordinator import HisenseDataUpdateCoordinator
-from .pyhisenseapi import HiSenseAC, HiSenseFridge
+from .pyhisenseapi import HiSenseAC, HiSenseFridge, HiSenseWasher
 
 
 async def async_setup_entry(hass: core.HomeAssistant, entry: config_entries.ConfigEntry):
@@ -22,11 +22,28 @@ async def async_setup_entry(hass: core.HomeAssistant, entry: config_entries.Conf
         device_type_name = device_info.get("device_type_name", "")
         device_name = device_info.get("device_name", "")
         device_code = device_info.get("device_code", "")
-        
-        friendly_name = f"{device_type_name}_{device_name}" if device_type_name and device_name else device_id
+
+        friendly_name = (
+            f"{device_type_name}_{device_name}"
+            if device_type_name and device_name
+            else device_id
+        )
         entity_name = device_code if device_code else device_id
 
-        if device_type == "冰箱":
+        if device_type == "洗衣机":
+            client = HiSenseWasher(
+                wifi_id=wifi_id,
+                device_id=device_id,
+                refresh_token=refresh_token,
+                session=session,
+                device_name=friendly_name,
+                entity_name=entity_name,
+                home_id=home_id,
+                access_token=access_token,
+                customer_id=customer_id,
+                partner_id=partner_id,
+            )
+        elif device_type == "冰箱":
             client = HiSenseFridge(
                 wifi_id=wifi_id,
                 device_id=device_id,
@@ -57,16 +74,30 @@ async def async_setup_entry(hass: core.HomeAssistant, entry: config_entries.Conf
         await coordinator.async_config_entry_first_refresh()
         hass.data[DOMAIN][entry.entry_id][device_id] = coordinator
 
-    await hass.config_entries.async_forward_entry_setups(
-        entry, ["climate", "switch", "button", "number", "sensor", "select"]
-    )
+    platforms = [
+        "climate",
+        "switch",
+        "button",
+        "number",
+        "sensor",
+        "binary_sensor",
+        "select",
+    ]
+    await hass.config_entries.async_forward_entry_setups(entry, platforms)
     return True
 
 
 async def async_unload_entry(hass: core.HomeAssistant, entry: config_entries.ConfigEntry):
-    unload_ok = await hass.config_entries.async_unload_platforms(
-        entry, ["climate", "switch", "button", "number", "sensor", "select"]
-    )
+    platforms = [
+        "climate",
+        "switch",
+        "button",
+        "number",
+        "sensor",
+        "binary_sensor",
+        "select",
+    ]
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, platforms)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id, None)
     return unload_ok

--- a/custom_components/hisense/binary_sensor.py
+++ b/custom_components/hisense/binary_sensor.py
@@ -1,0 +1,47 @@
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+
+from .const import DOMAIN
+from .entity import HisenseEntity
+
+WASHER_BINARY_SENSOR_DESCRIPTIONS = (
+    BinarySensorEntityDescription(
+        key="power_on", translation_key="washer_power", icon="mdi:power"
+    ),
+    BinarySensorEntityDescription(
+        key="gate_locked", translation_key="washer_gate_lock", icon="mdi:lock"
+    ),
+    BinarySensorEntityDescription(
+        key="child_lock",
+        translation_key="washer_child_lock",
+        icon="mdi:account-lock",
+    ),
+)
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    coordinators = hass.data[DOMAIN][config_entry.entry_id]
+    washer_coordinators = [
+        coordinator
+        for coordinator in coordinators.values()
+        if coordinator.device_type == "洗衣机"
+    ]
+    async_add_entities(
+        HisenseWasherBinarySensor(coordinator, description)
+        for coordinator in washer_coordinators
+        for description in WASHER_BINARY_SENSOR_DESCRIPTIONS
+    )
+
+
+class HisenseWasherBinarySensor(HisenseEntity, BinarySensorEntity):
+    entity_description: BinarySensorEntityDescription
+
+    def __init__(self, coordinator, description):
+        super().__init__(coordinator, description.key, description.key, description.icon)
+        self.entity_description = description
+
+    @property
+    def is_on(self):
+        return self.status.get(self.entity_description.key)

--- a/custom_components/hisense/coordinator.py
+++ b/custom_components/hisense/coordinator.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
-from .pyhisenseapi import HiSenseAC, HiSenseFridge
+from .pyhisenseapi import HiSenseAC, HiSenseFridge, HiSenseWasher
 
 import logging
 
@@ -23,7 +23,7 @@ class HisenseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def __init__(
         self,
         hass: HomeAssistant,
-        client: HiSenseAC | HiSenseFridge,
+        client: HiSenseAC | HiSenseFridge | HiSenseWasher,
         device_type: str = "空调"
     ) -> None:
         """Initialize the coordinator."""

--- a/custom_components/hisense/entity.py
+++ b/custom_components/hisense/entity.py
@@ -9,7 +9,7 @@ from homeassistant.util import slugify
 
 from .const import DOMAIN
 from .coordinator import HisenseDataUpdateCoordinator
-from .pyhisenseapi import HiSenseAC, HiSenseFridge
+from .pyhisenseapi import HiSenseAC, HiSenseFridge, HiSenseWasher
 
 
 class HisenseEntity(CoordinatorEntity[HisenseDataUpdateCoordinator]):
@@ -37,7 +37,7 @@ class HisenseEntity(CoordinatorEntity[HisenseDataUpdateCoordinator]):
             self._attr_icon = icon
 
     @property
-    def client(self) -> HiSenseAC | HiSenseFridge:
+    def client(self) -> HiSenseAC | HiSenseFridge | HiSenseWasher:
         """Return the device API client."""
         return self.coordinator.client
 
@@ -55,6 +55,9 @@ class HisenseEntity(CoordinatorEntity[HisenseDataUpdateCoordinator]):
         if device_type == "冰箱":
             translation_key = "hisense_fridge"
             name = device_name if device_name else "Hisense Fridge"
+        elif device_type == "洗衣机":
+            translation_key = "hisense_washer"
+            name = device_name if device_name else "Hisense Washer"
         else:
             translation_key = "hisense_ac"
             name = device_name if device_name else "Hisense AC"

--- a/custom_components/hisense/pyhisenseapi.py
+++ b/custom_components/hisense/pyhisenseapi.py
@@ -14,6 +14,42 @@ _PORTAL_APP_KEY = "commonweb"
 _PORTAL_APP_SECRET = "MORZRbkuiWxjp+SM4vR_GxY4pZxLZ6rn"
 _PORTAL_AES_IV = _PORTAL_APP_SECRET[:16].encode("ascii")
 
+WASHER_PHASE_LABELS = {
+    0: "待机",
+    1: "预约等待",
+    2: "浸泡",
+    3: "预洗",
+    4: "主洗",
+    5: "漂洗",
+    6: "脱水",
+    7: "洗涤完成",
+    8: "烘干",
+    9: "风干",
+    10: "晾护",
+}
+_WASHER_MIN_STATUS_VALUES = 101
+_WASHER_TEMPERATURE_LABELS = {
+    0: "常温",
+    2: "20 °C",
+    3: "30 °C",
+    4: "40 °C",
+    6: "60 °C",
+    9: "95 °C",
+}
+_WASHER_DRY_SETTING_LABELS = {
+    0: "关闭",
+    1: "即穿",
+    2: "熨烫",
+    3: "存放",
+    4: "定时烘 1 挡",
+    5: "定时烘 2 挡",
+    6: "定时烘 3 挡",
+    7: "定时烘 4 挡",
+    8: "定时烘 5 挡",
+    9: "定时烘 6 挡",
+}
+
+
 class HiSenseLogin:
     def __init__(self, session):
         self.session = session
@@ -167,22 +203,65 @@ class HiSenseLogin:
         )
 
 
-def _device_type(device: dict) -> str | None:
-    product = device.get("product") or {}
-    text = " ".join(
-        str(value or "")
-        for value in (
-            device.get("categoryCode"),
-            device.get("deviceTypeName"),
-            product.get("name"),
-            product.get("code"),
-        )
-    ).lower()
+def _device_type_from_name(device_type_name) -> str | None:
+    if not isinstance(device_type_name, str):
+        return None
+    text = device_type_name.lower()
     if "aircondition" in text or "air_condition" in text or "空调" in text:
         return "空调"
     if "refrigerat" in text or "fridge" in text or "冰箱" in text:
         return "冰箱"
+    if "washer" in text or "washing" in text or "洗衣" in text:
+        return "洗衣机"
     return None
+
+
+def _device_text(value) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _is_supported_00f_washer(device: dict) -> bool:
+    """Return whether a washer belongs to the verified 00f/E3S family."""
+    product = device.get("product") or {}
+    protocol_types = {
+        _device_text(device.get(key)).lower()
+        for key in ("deviceType", "deviceTypeCode", "typeCode")
+        if _device_text(device.get(key))
+    }
+    model = " ".join(
+        filter(
+            None,
+            (
+                _device_text(device.get("deviceCode")),
+                _device_text(device.get("deviceName")),
+                _device_text(product.get("code")),
+                _device_text(product.get("name")),
+            ),
+        )
+    ).upper()
+    return "00f" in protocol_types or "E3S" in model
+
+
+def _device_type(device: dict) -> str | None:
+    product = device.get("product") or {}
+    device_type = _device_type_from_name(
+        " ".join(
+            str(value or "")
+            for value in (
+                device.get("categoryCode"),
+                device.get("deviceTypeName"),
+                product.get("name"),
+                product.get("code"),
+            )
+        )
+    )
+    if device_type == "洗衣机" and not _is_supported_00f_washer(device):
+        _LOGGER.warning(
+            "Skipping unsupported Hisense washer model; only verified "
+            "00f/E3S devices are enabled"
+        )
+        return None
+    return device_type
 
 
 def _as_int(value):
@@ -663,6 +742,173 @@ class _HiSenseDevice:
             {key: value for key, value in values.items() if value is not None}
         )
         return self.get_status()
+
+
+class HiSenseWasher(_HiSenseDevice):
+    """Read-only AIHome client for verified Hisense 00f/E3S washers."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.status = {
+            "protocol_payload_length": 0,
+            "protocol_payload_sha256": "",
+            "protocol_raw_values": [],
+            "protocol_changed_indices": [],
+            "protocol_nonzero_values": {},
+        }
+
+    @classmethod
+    def _status_success(cls, result) -> bool:
+        if cls._success(result):
+            return True
+        if not isinstance(result, dict):
+            return False
+        payload = result.get("payload")
+        if isinstance(payload, dict) and "status" in payload:
+            return False
+        response = result.get("response")
+        return isinstance(response, dict) and isinstance(
+            response.get("deviceStatusList"), list
+        )
+
+    @classmethod
+    def _extract_status_values(cls, result) -> list[int]:
+        if not isinstance(result, dict):
+            raise ValueError("missing response object")
+
+        payload = result.get("payload") or {}
+        raw_status = payload.get("deviceStatus") if isinstance(payload, dict) else None
+        if raw_status is None:
+            response = result.get("response") or {}
+            status_list = (
+                response.get("deviceStatusList")
+                if isinstance(response, dict)
+                else None
+            )
+            if isinstance(status_list, list) and status_list:
+                first_status = status_list[0]
+                if isinstance(first_status, dict):
+                    raw_status = first_status.get("deviceStatus")
+
+        if isinstance(raw_status, str):
+            values = [int(value.strip()) for value in raw_status.split(",")]
+        elif isinstance(raw_status, list):
+            values = [int(value) for value in raw_status]
+        else:
+            raise ValueError("missing deviceStatus")
+
+        if len(values) < _WASHER_MIN_STATUS_VALUES:
+            raise ValueError(
+                f"washer status has {len(values)} values; expected at least "
+                f"{_WASHER_MIN_STATUS_VALUES}"
+            )
+        return values
+
+    def _update_status_from_result(self, result) -> bool:
+        try:
+            values = self._extract_status_values(result)
+        except (TypeError, ValueError):
+            _LOGGER.error("Failed to parse Hisense washer status", exc_info=True)
+            return False
+
+        previous = self.status.get("protocol_raw_values", [])
+        changed = (
+            [
+                index
+                for index in range(max(len(previous), len(values)))
+                if (previous[index] if index < len(previous) else None)
+                != (values[index] if index < len(values) else None)
+            ]
+            if previous
+            else []
+        )
+        canonical = ",".join(str(value) for value in values)
+        phase = values[11]
+        power_on = values[9] == 1
+        run_state = values[8]
+        if not power_on:
+            machine_state = "关机"
+        elif phase == 7:
+            machine_state = "完成"
+        elif run_state == 1:
+            machine_state = "运行"
+        elif run_state == 0 and phase == 0:
+            machine_state = "待机"
+        elif run_state == 0:
+            machine_state = "暂停"
+        else:
+            machine_state = f"未知 ({run_state})"
+
+        self.status = {
+            "machine_state": machine_state,
+            "run_state": run_state,
+            "power_on": power_on,
+            "phase": phase,
+            "phase_label": WASHER_PHASE_LABELS.get(phase, f"未知 ({phase})"),
+            "program": values[12],
+            "remaining_minutes": values[28] * 256 + values[29],
+            "gate_locked": values[6] == 1,
+            "fault": values[27],
+            "motor_speed": values[13] * 256 + values[14],
+            "temperature_raw": values[15],
+            "configured_spin": values[37] * 100,
+            "configured_temperature": _WASHER_TEMPERATURE_LABELS.get(
+                values[38], f"未知 ({values[38]})"
+            ),
+            "child_lock": values[100] == 1,
+            "dry_setting": _WASHER_DRY_SETTING_LABELS.get(
+                values[80], f"未知 ({values[80]})"
+            ),
+            "protocol_payload_length": len(values),
+            "protocol_payload_sha256": hashlib.sha256(
+                canonical.encode()
+            ).hexdigest(),
+            "protocol_raw_values": values,
+            "protocol_changed_indices": changed,
+            "protocol_nonzero_values": {
+                str(index): value
+                for index, value in enumerate(values)
+                if value != 0
+            },
+        }
+        _LOGGER.debug(
+            "Hisense washer status: length=%s sha256=%s changed_indices=%s",
+            len(values),
+            self.status["protocol_payload_sha256"],
+            changed,
+        )
+        return True
+
+    async def check_status(self):
+        if not await self.refresh():
+            return None
+        try:
+            result = await self._post(
+                self.session,
+                self.access_token,
+                self.customer_id,
+                "/4.0/iot/devices/detail",
+                {"deviceId": str(self.device_id), "partnerId": str(self.partner_id)},
+            )
+        except Exception:
+            _LOGGER.error("Hisense AIHome washer status request failed", exc_info=True)
+            return None
+        if not self._status_success(result) or not self._update_status_from_result(
+            result
+        ):
+            return None
+        return self.get_status()
+
+    async def _send_aihome_action(self, command, params, *, source_name=None):
+        """Keep washer support read-only even if an inherited method is called."""
+        return False
+
+    async def _send_aihome_label(self, label_key: str, label_value) -> bool:
+        """Keep washer support read-only even if an inherited method is called."""
+        return False
+
+    def get_status(self):
+        return json.loads(json.dumps(self.status))
 
 
 class HiSenseAC(_HiSenseDevice):

--- a/custom_components/hisense/sensor.py
+++ b/custom_components/hisense/sensor.py
@@ -6,7 +6,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import UnitOfEnergy, UnitOfTime
+from homeassistant.const import EntityCategory, UnitOfEnergy, UnitOfTime
 from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
@@ -31,6 +31,62 @@ AC_ENERGY_SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
     ),
 )
 
+WASHER_SENSOR_DESCRIPTIONS: tuple[SensorEntityDescription, ...] = (
+    SensorEntityDescription(
+        key="machine_state",
+        translation_key="washer_run_state",
+        icon="mdi:washing-machine",
+    ),
+    SensorEntityDescription(
+        key="phase_label",
+        translation_key="washer_phase",
+        icon="mdi:progress-clock",
+    ),
+    SensorEntityDescription(
+        key="program",
+        translation_key="washer_program",
+        icon="mdi:format-list-numbered",
+    ),
+    SensorEntityDescription(
+        key="remaining_minutes",
+        translation_key="washer_remaining_time",
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        icon="mdi:timer-outline",
+    ),
+    SensorEntityDescription(
+        key="fault",
+        translation_key="washer_fault",
+        icon="mdi:alert-circle-outline",
+    ),
+    SensorEntityDescription(
+        key="motor_speed",
+        translation_key="washer_motor_speed",
+        native_unit_of_measurement="rpm",
+        icon="mdi:rotate-right",
+    ),
+    SensorEntityDescription(
+        key="temperature_raw",
+        translation_key="washer_temperature_raw",
+        icon="mdi:thermometer",
+    ),
+    SensorEntityDescription(
+        key="configured_spin",
+        translation_key="washer_configured_spin",
+        native_unit_of_measurement="rpm",
+        icon="mdi:rotate-right",
+    ),
+    SensorEntityDescription(
+        key="configured_temperature",
+        translation_key="washer_configured_temperature",
+        icon="mdi:thermometer-cog",
+    ),
+    SensorEntityDescription(
+        key="dry_setting",
+        translation_key="washer_dry_setting",
+        icon="mdi:tumble-dryer",
+    ),
+)
+
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     coordinators = hass.data[DOMAIN][config_entry.entry_id]
@@ -42,6 +98,67 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         for desc in AC_ENERGY_SENSOR_DESCRIPTIONS
     ]
     async_add_entities(sensors)
+
+    washer_coordinators = [
+        coordinator
+        for coordinator in coordinators.values()
+        if coordinator.device_type == "洗衣机"
+    ]
+    async_add_entities(
+        HisenseWasherSensor(coordinator, description)
+        for coordinator in washer_coordinators
+        for description in WASHER_SENSOR_DESCRIPTIONS
+    )
+    async_add_entities(
+        HisenseWasherProtocolSensor(coordinator)
+        for coordinator in washer_coordinators
+    )
+
+
+class HisenseWasherSensor(HisenseEntity, SensorEntity):
+    entity_description: SensorEntityDescription
+
+    def __init__(self, coordinator, description: SensorEntityDescription):
+        super().__init__(
+            coordinator,
+            description.key,
+            description.key,
+            description.icon,
+        )
+        self.entity_description = description
+
+    @property
+    def native_value(self):
+        return self.status.get(self.entity_description.key)
+
+
+class HisenseWasherProtocolSensor(HisenseEntity, SensorEntity):
+    """Expose a sanitized read-only washer protocol snapshot."""
+
+    _attr_translation_key = "washer_protocol_debug"
+    _attr_icon = "mdi:washing-machine"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator):
+        super().__init__(
+            coordinator,
+            "washer_protocol_debug",
+            "washer_protocol_debug",
+        )
+
+    @property
+    def native_value(self):
+        return self.status.get("protocol_payload_sha256", "")[:12]
+
+    @property
+    def extra_state_attributes(self):
+        return {
+            "payload_length": self.status.get("protocol_payload_length", 0),
+            "changed_indices": self.status.get("protocol_changed_indices", []),
+            "nonzero_values": self.status.get("protocol_nonzero_values", {}),
+            "read_only_debug": True,
+        }
 
 
 class HisenseACEnergySensor(HisenseEntity, SensorEntity):

--- a/custom_components/hisense/translations/en.json
+++ b/custom_components/hisense/translations/en.json
@@ -33,6 +33,9 @@
     },
     "hisense_fridge": {
       "name": "Hisense Fridge"
+    },
+    "hisense_washer": {
+      "name": "Hisense Washer"
     }
   },
   "entity": {
@@ -77,6 +80,50 @@
       },
       "run_time": {
         "name": "Today's runtime"
+      },
+      "washer_protocol_debug": {
+        "name": "Washer Protocol State"
+      },
+      "washer_run_state": {
+        "name": "Run state"
+      },
+      "washer_phase": {
+        "name": "Cycle phase"
+      },
+      "washer_program": {
+        "name": "Program code"
+      },
+      "washer_remaining_time": {
+        "name": "Remaining time"
+      },
+      "washer_fault": {
+        "name": "Fault code"
+      },
+      "washer_motor_speed": {
+        "name": "Motor speed"
+      },
+      "washer_temperature_raw": {
+        "name": "Temperature raw value"
+      },
+      "washer_configured_spin": {
+        "name": "Configured spin"
+      },
+      "washer_configured_temperature": {
+        "name": "Configured temperature"
+      },
+      "washer_dry_setting": {
+        "name": "Dry setting"
+      }
+    },
+    "binary_sensor": {
+      "washer_power": {
+        "name": "Power"
+      },
+      "washer_gate_lock": {
+        "name": "Door lock"
+      },
+      "washer_child_lock": {
+        "name": "Child lock"
       }
     }
   }

--- a/custom_components/hisense/translations/zh-Hans.json
+++ b/custom_components/hisense/translations/zh-Hans.json
@@ -33,6 +33,9 @@
     },
     "hisense_fridge": {
       "name": "海信冰箱"
+    },
+    "hisense_washer": {
+      "name": "海信洗衣机"
     }
   },
   "entity": {
@@ -77,6 +80,50 @@
       },
       "run_time": {
         "name": "今日运行时间"
+      },
+      "washer_protocol_debug": {
+        "name": "洗衣机协议状态"
+      },
+      "washer_run_state": {
+        "name": "运行状态"
+      },
+      "washer_phase": {
+        "name": "洗衣阶段"
+      },
+      "washer_program": {
+        "name": "程序代码"
+      },
+      "washer_remaining_time": {
+        "name": "剩余时间"
+      },
+      "washer_fault": {
+        "name": "故障代码"
+      },
+      "washer_motor_speed": {
+        "name": "当前转速"
+      },
+      "washer_temperature_raw": {
+        "name": "温度原始值"
+      },
+      "washer_configured_spin": {
+        "name": "设定转速"
+      },
+      "washer_configured_temperature": {
+        "name": "设定温度"
+      },
+      "washer_dry_setting": {
+        "name": "烘干设定"
+      }
+    },
+    "binary_sensor": {
+      "washer_power": {
+        "name": "电源"
+      },
+      "washer_gate_lock": {
+        "name": "门锁"
+      },
+      "washer_child_lock": {
+        "name": "童锁"
       }
     }
   }

--- a/tests/test_washer_protocol.py
+++ b/tests/test_washer_protocol.py
@@ -1,0 +1,261 @@
+"""Standalone tests for Hisense 00f washer protocol support."""
+
+import asyncio
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = (
+    Path(__file__).parents[1]
+    / "custom_components"
+    / "hisense"
+    / "pyhisenseapi.py"
+)
+SPEC = importlib.util.spec_from_file_location("pyhisenseapi", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def washer_result(values):
+    return {
+        "response": {
+            "deviceStatusList": [
+                {"deviceStatus": ",".join(map(str, values))}
+            ]
+        }
+    }
+
+
+def test_washer_device_type_detection():
+    assert MODULE._device_type_from_name("滚筒洗衣机") == "洗衣机"
+    assert MODULE._device_type_from_name("洗衣干衣机") == "洗衣机"
+    assert MODULE._device_type_from_name("智能空调") == "空调"
+    assert MODULE._device_type_from_name("对开门冰箱") == "冰箱"
+
+
+def test_washer_support_is_restricted_to_verified_00f_or_e3s_family():
+    assert MODULE._is_supported_00f_washer({"deviceType": "00f"})
+    assert MODULE._is_supported_00f_washer({"deviceCode": "WH120E3S"})
+    assert not MODULE._is_supported_00f_washer({"deviceCode": "OTHER123"})
+
+
+def test_device_classification_requires_washer_identity_and_verified_family():
+    assert (
+        MODULE._device_type(
+            {"deviceTypeName": "滚筒洗衣机", "deviceType": "00f"}
+        )
+        == "洗衣机"
+    )
+    assert MODULE._device_type({"deviceTypeName": "滚筒洗衣机"}) is None
+    assert MODULE._device_type({"deviceType": "00f"}) is None
+    assert MODULE._device_type({"deviceTypeName": "智能空调"}) == "空调"
+    assert MODULE._device_type({"deviceTypeName": "对开门冰箱"}) == "冰箱"
+
+
+def test_washer_status_snapshot_and_diff():
+    client = MODULE.HiSenseWasher("wifi", "device", "refresh", None)
+    first_values = [0] * 101
+    first_values[1] = 1
+    first_values[3] = 7
+    second_values = first_values.copy()
+    second_values[1] = 2
+
+    assert client._update_status_from_result(washer_result(first_values))
+    assert client.get_status()["protocol_payload_length"] == 101
+    assert client.get_status()["protocol_nonzero_values"] == {"1": 1, "3": 7}
+    assert client.get_status()["protocol_changed_indices"] == []
+
+    assert client._update_status_from_result(washer_result(second_values))
+    assert client.get_status()["protocol_changed_indices"] == [1]
+    assert len(client.get_status()["protocol_payload_sha256"]) == 64
+
+
+def test_washer_aihome_payload_shape_is_supported():
+    values = [0] * 101
+    values[9] = 1
+    client = MODULE.HiSenseWasher("wifi", "device", "refresh", None)
+
+    assert client._update_status_from_result(
+        {
+            "payload": {
+                "status": "SUCCESS",
+                "deviceStatus": ",".join(map(str, values)),
+            }
+        }
+    )
+    assert client.get_status()["power_on"] is True
+
+
+@pytest.mark.parametrize(
+    "result_factory",
+    [
+        lambda values: {
+            "payload": {
+                "status": "SUCCESS",
+                "deviceStatus": ",".join(map(str, values)),
+            }
+        },
+        washer_result,
+    ],
+)
+def test_washer_check_status_accepts_successful_response_shapes(
+    monkeypatch, result_factory
+):
+    values = [0] * 101
+    values[9] = 1
+    client = MODULE.HiSenseWasher("wifi", "device", "refresh", None)
+
+    async def refresh():
+        return True
+
+    async def post(*args, **kwargs):
+        return result_factory(values)
+
+    monkeypatch.setattr(client, "refresh", refresh)
+    monkeypatch.setattr(client, "_post", post)
+
+    status = asyncio.run(client.check_status())
+    assert status is not None
+    assert status["power_on"] is True
+
+
+def test_washer_check_status_rejects_explicit_failure(monkeypatch):
+    values = [0] * 101
+    client = MODULE.HiSenseWasher("wifi", "device", "refresh", None)
+    baseline = client.get_status()
+
+    async def refresh():
+        return True
+
+    async def post(*args, **kwargs):
+        result = washer_result(values)
+        result["payload"] = {"status": "FAILURE"}
+        return result
+
+    monkeypatch.setattr(client, "refresh", refresh)
+    monkeypatch.setattr(client, "_post", post)
+
+    assert asyncio.run(client.check_status()) is None
+    assert client.get_status() == baseline
+
+
+def test_washer_snapshot_is_a_copy():
+    client = MODULE.HiSenseWasher("wifi", "device", "refresh", None)
+    values = [0] * 101
+    values[0] = 1
+    client._update_status_from_result(washer_result(values))
+    snapshot = client.get_status()
+    snapshot["protocol_raw_values"][0] = 99
+    assert client.get_status()["protocol_raw_values"] == values
+
+
+def test_washer_cylinder_fields_use_zero_based_apk_lut():
+    raw = [0] * 106
+    raw[6] = 1
+    raw[8] = 1
+    raw[9] = 1
+    raw[11] = 8
+    raw[12] = 35
+    raw[13], raw[14] = 3, 32
+    raw[15] = 42
+    raw[27] = 7
+    raw[28], raw[29] = 1, 44
+    raw[37] = 12
+    raw[38] = 6
+    raw[80] = 2
+    raw[100] = 1
+    client = MODULE.HiSenseWasher("wifi", "device", "refresh", None)
+
+    assert client._update_status_from_result(washer_result(raw))
+    status = client.get_status()
+    assert status["run_state"] == 1
+    assert status["power_on"] is True
+    assert status["phase"] == 8
+    assert status["phase_label"] == "烘干"
+    assert status["program"] == 35
+    assert status["remaining_minutes"] == 300
+    assert status["gate_locked"] is True
+    assert status["fault"] == 7
+    assert status["motor_speed"] == 800
+    assert status["temperature_raw"] == 42
+    assert status["configured_spin"] == 1200
+    assert status["configured_temperature"] == "60 °C"
+    assert status["child_lock"] is True
+    assert status["dry_setting"] == "熨烫"
+
+
+def test_washer_preserves_all_verified_dry_setting_labels():
+    client = MODULE.HiSenseWasher("wifi", "device", "refresh", None)
+    for setting, label in enumerate(
+        (
+            "关闭",
+            "即穿",
+            "熨烫",
+            "存放",
+            "定时烘 1 挡",
+            "定时烘 2 挡",
+            "定时烘 3 挡",
+            "定时烘 4 挡",
+            "定时烘 5 挡",
+            "定时烘 6 挡",
+        )
+    ):
+        raw = [0] * 101
+        raw[80] = setting
+        assert client._update_status_from_result(washer_result(raw))
+        assert client.get_status()["dry_setting"] == label
+
+
+def test_washer_short_payload_is_rejected_without_losing_state():
+    client = MODULE.HiSenseWasher("wifi", "device", "refresh", None)
+    baseline = client.get_status()
+    assert not client._update_status_from_result(washer_result([0, 1, 2]))
+    assert client.get_status() == baseline
+
+
+@pytest.mark.parametrize(
+    ("phase", "label"),
+    list(
+        enumerate(
+            (
+                "待机",
+                "预约等待",
+                "浸泡",
+                "预洗",
+                "主洗",
+                "漂洗",
+                "脱水",
+                "洗涤完成",
+                "烘干",
+                "风干",
+                "晾护",
+            )
+        )
+    ),
+)
+def test_washer_phase_labels(phase, label):
+    assert MODULE.WASHER_PHASE_LABELS[phase] == label
+
+
+def test_washer_machine_state_distinguishes_standby_pause_and_complete():
+    client = MODULE.HiSenseWasher("wifi", "device", "refresh", None)
+
+    def update(run_state, phase):
+        raw = [0] * 101
+        raw[8], raw[9], raw[11], raw[29] = run_state, 1, phase, 10
+        assert client._update_status_from_result(washer_result(raw))
+        return client.get_status()["machine_state"]
+
+    assert update(0, 0) == "待机"
+    assert update(0, 4) == "暂停"
+    assert update(0, 7) == "完成"
+
+
+def test_washer_exposes_no_device_controls():
+    client = MODULE.HiSenseWasher("wifi", "device", "refresh", None)
+    assert not hasattr(client, "turn_on")
+    assert not hasattr(client, "set_temperature")
+    assert not hasattr(client, "set_prompt_sound")


### PR DESCRIPTION
## Summary

- add China-cloud discovery and status parsing for verified `00f` / E3S cylinder washers
- expose washer state, phase, program, remaining time, fault, motor speed, configured spin/temperature, drying mode, power, door lock, and child lock entities
- retain a disabled-by-default diagnostic sensor without attaching the full raw status array to Recorder
- add English and Simplified Chinese translations and bump the integration to `1.7.0`
- preserve existing air-conditioner and refrigerator behavior

## Protocol grounding

The status indexes and enums are derived from the `00f` resources bundled in the official Hisense Smart Home Android app. APK indexes are 1-based and are converted to the cloud status array’s 0-based positions. Support is deliberately restricted to positively identified `00f` or E3S-family washers.

## Safety / scope

This PR is intentionally **read-only** for washers. Although the APK identifies logical pause/resume command ID `3`, a supervised cloud request was accepted by the API but did not change the physical washer state. The native app bridge therefore appears to add unverified envelope data. No washer control entities or speculative command implementation are included.

## Validation

- `18 passed` with pytest
- Python compilation passed
- integration JSON validation passed
- staged diff whitespace check passed with the repository’s existing CRLF convention
- deployed to a live Home Assistant instance after `check_config`; verified entity updates, HTTP 200, and no Hisense traceback/error in startup logs